### PR TITLE
Integration of Entando keycloak plugin into the entando-de-app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
         <struts2.version>2.5.17</struts2.version>
         <postgres.driver.version>9.4.1212</postgres.driver.version>
         <jetty.version>9.4.8.v20180619</jetty.version>
+        <keycloak.enabled>false</keycloak.enabled>
+        <keycloak.authUrl>http://${docker.host.address}:8081/auth</keycloak.authUrl>
+        <keycloak.realm>entando-development</keycloak.realm>
+        <keycloak.clientId>entando-core</keycloak.clientId>
+        <keycloak.clientSecret>930837f0-95b2-4eeb-b303-82a56cac76e6</keycloak.clientSecret>
+        <keycloak.publicClientId>entando-web</keycloak.publicClientId>
     </properties>
     <dependencies>
         <dependency>
@@ -475,11 +481,6 @@
             <id>keycloak</id>
             <properties>
                 <keycloak.enabled>true</keycloak.enabled>
-                <keycloak.authUrl>http://${docker.host.address}:8081/auth</keycloak.authUrl>
-                <keycloak.realm>entando-development</keycloak.realm>
-                <keycloak.clientId>entando-core</keycloak.clientId>
-                <keycloak.clientSecret>930837f0-95b2-4eeb-b303-82a56cac76e6</keycloak.clientSecret>
-                <keycloak.publicClientId>entando-web</keycloak.publicClientId>
             </properties>
         </profile>
     </profiles>
@@ -644,7 +645,7 @@
                                     <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
                                     <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>
                                     <KEYCLOAK_CLIENTSECRET>${keycloak.clientSecret}</KEYCLOAK_CLIENTSECRET>
-                                    <KEYCLOAK_PUBLICCLIENTID>entando-public</KEYCLOAK_PUBLICCLIENTID>
+                                    <KEYCLOAK_PUBLICCLIENTID>${keycloak.publicClientId}</KEYCLOAK_PUBLICCLIENTID>
                                 </env>
                                 <runCmds>
                                     <run>${server.init.command}</run>
@@ -679,7 +680,7 @@
                                     <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
                                     <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>
                                     <KEYCLOAK_CLIENTSECRET>${keycloak.clientSecret}</KEYCLOAK_CLIENTSECRET>
-                                    <KEYCLOAK_PUBLICCLIENTID>entando-public</KEYCLOAK_PUBLICCLIENTID>
+                                    <KEYCLOAK_PUBLICCLIENTID>${keycloak.publicClientId}</KEYCLOAK_PUBLICCLIENTID>
                                 </env>
                                 <dependsOn>
                                     <container>${entando.engine.depends.on}</container>

--- a/pom.xml
+++ b/pom.xml
@@ -133,26 +133,6 @@
             <type>war</type>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>3.0.18.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.18.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.6.3.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.3.0.Final</version>
-        </dependency>
-        <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
             <version>${entando.version}</version>
@@ -493,6 +473,7 @@
         <profile>
             <id>keycloak</id>
             <properties>
+                <keycloak.enabled>true</keycloak.enabled>
                 <keycloak.authUrl>http://${docker.host.address}:8081/auth</keycloak.authUrl>
                 <keycloak.realm>entando-development</keycloak.realm>
                 <keycloak.clientId>entando-core</keycloak.clientId>
@@ -657,6 +638,7 @@
                                     <DB_ENVIRONMENT>${env.db.environment}</DB_ENVIRONMENT>
                                     <DB_STARTUP_CHECK>true</DB_STARTUP_CHECK>
                                     <LOGNAME>/var/log/entando/engine.log</LOGNAME><!--workaround until upstream images are fixed-->
+                                    <KEYCLOAK_ENABLED>${keycloak.enabled}</KEYCLOAK_ENABLED>
                                     <KEYCLOAK_AUTHURL>${keycloak.authUrl}</KEYCLOAK_AUTHURL>
                                     <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
                                     <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>
@@ -691,6 +673,7 @@
                                     <SERVDB_JNDI>${servdb.jndi}</SERVDB_JNDI>
                                     <DB_ENVIRONMENT>${env.db.environment}</DB_ENVIRONMENT>
                                     <DB_STARTUP_CHECK>false</DB_STARTUP_CHECK>
+                                    <KEYCLOAK_ENABLED>${keycloak.enabled}</KEYCLOAK_ENABLED>
                                     <KEYCLOAK_AUTHURL>${keycloak.authUrl}</KEYCLOAK_AUTHURL>
                                     <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
                                     <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <skipSmokeTests>true</skipSmokeTests>
         <autoCreateNetwork>true</autoCreateNetwork>
         <entando.version>5.2.0-SNAPSHOT</entando.version>
+        <entando.keycloak.plugin.version>5.1.3</entando.keycloak.plugin.version>
         <spring.version>5.0.8.RELEASE</spring.version>
         <struts2.version>2.5.17</struts2.version>
         <postgres.driver.version>9.4.1212</postgres.driver.version>
@@ -129,7 +130,7 @@
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-keycloak-auth</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${entando.keycloak.plugin.version}</version>
             <type>war</type>
         </dependency>
         <dependency>
@@ -478,7 +479,7 @@
                 <keycloak.realm>entando-development</keycloak.realm>
                 <keycloak.clientId>entando-core</keycloak.clientId>
                 <keycloak.clientSecret>930837f0-95b2-4eeb-b303-82a56cac76e6</keycloak.clientSecret>
-                <keycloak.publicClientId>entando-core</keycloak.publicClientId>
+                <keycloak.publicClientId>entando-web</keycloak.publicClientId>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,26 @@
             <type>war</type>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>3.0.18.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxrs</artifactId>
+            <version>3.0.18.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>3.6.3.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.3.0.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
             <version>${entando.version}</version>
@@ -473,7 +493,7 @@
         <profile>
             <id>keycloak</id>
             <properties>
-                <keycloak.authUrl>localhost:8081</keycloak.authUrl>
+                <keycloak.authUrl>http://${docker.host.address}:8081/auth</keycloak.authUrl>
                 <keycloak.realm>entando-development</keycloak.realm>
                 <keycloak.clientId>entando-core</keycloak.clientId>
                 <keycloak.clientSecret>930837f0-95b2-4eeb-b303-82a56cac76e6</keycloak.clientSecret>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
+            <artifactId>entando-keycloak-auth</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
             <version>${entando.version}</version>
             <type>test-jar</type>
@@ -463,7 +469,16 @@
                 <!-- No DB work required from the server image. Just set the build_id -->
                 <server.init.command>echo $(date +%s) > /entando-data-templates/build_id</server.init.command>
             </properties>
-
+        </profile>
+        <profile>
+            <id>keycloak</id>
+            <properties>
+                <keycloak.authUrl>localhost:8081</keycloak.authUrl>
+                <keycloak.realm>entando-development</keycloak.realm>
+                <keycloak.clientId>entando-core</keycloak.clientId>
+                <keycloak.clientSecret>930837f0-95b2-4eeb-b303-82a56cac76e6</keycloak.clientSecret>
+                <keycloak.publicClientId>entando-core</keycloak.publicClientId>
+            </properties>
         </profile>
     </profiles>
     <build>
@@ -561,6 +576,10 @@
                                     <SERVDB_DATABASE>${servdb.database}</SERVDB_DATABASE>
                                     <SERVDB_JNDI>${servdb.jndi}</SERVDB_JNDI>
                                     <DB_ENVIRONMENT>${env.db.environment}</DB_ENVIRONMENT>
+                                    <KEYCLOAK_AUTHURL>${keycloak.authUrl}</KEYCLOAK_AUTHURL>
+                                    <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
+                                    <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>
+                                    <KEYCLOAK_CLIENTSECRET>${keycloak.clientSecret}</KEYCLOAK_CLIENTSECRET>
                                 </env>
                                 <runCmds>
                                     <run>${db.init.command}</run>

--- a/pom.xml
+++ b/pom.xml
@@ -214,11 +214,6 @@
             <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.3.0.Final</version>
-        </dependency>
     </dependencies>
 
     <profiles>
@@ -581,10 +576,6 @@
                                     <SERVDB_DATABASE>${servdb.database}</SERVDB_DATABASE>
                                     <SERVDB_JNDI>${servdb.jndi}</SERVDB_JNDI>
                                     <DB_ENVIRONMENT>${env.db.environment}</DB_ENVIRONMENT>
-                                    <KEYCLOAK_AUTHURL>${keycloak.authUrl}</KEYCLOAK_AUTHURL>
-                                    <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
-                                    <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>
-                                    <KEYCLOAK_CLIENTSECRET>${keycloak.clientSecret}</KEYCLOAK_CLIENTSECRET>
                                 </env>
                                 <runCmds>
                                     <run>${db.init.command}</run>
@@ -646,7 +637,11 @@
                                     <DB_ENVIRONMENT>${env.db.environment}</DB_ENVIRONMENT>
                                     <DB_STARTUP_CHECK>true</DB_STARTUP_CHECK>
                                     <LOGNAME>/var/log/entando/engine.log</LOGNAME><!--workaround until upstream images are fixed-->
-
+                                    <KEYCLOAK_AUTHURL>${keycloak.authUrl}</KEYCLOAK_AUTHURL>
+                                    <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
+                                    <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>
+                                    <KEYCLOAK_CLIENTSECRET>${keycloak.clientSecret}</KEYCLOAK_CLIENTSECRET>
+                                    <KEYCLOAK_PUBLICCLIENTID>entando-public</KEYCLOAK_PUBLICCLIENTID>
                                 </env>
                                 <runCmds>
                                     <run>${server.init.command}</run>
@@ -676,6 +671,11 @@
                                     <SERVDB_JNDI>${servdb.jndi}</SERVDB_JNDI>
                                     <DB_ENVIRONMENT>${env.db.environment}</DB_ENVIRONMENT>
                                     <DB_STARTUP_CHECK>false</DB_STARTUP_CHECK>
+                                    <KEYCLOAK_AUTHURL>${keycloak.authUrl}</KEYCLOAK_AUTHURL>
+                                    <KEYCLOAK_REALM>${keycloak.realm}</KEYCLOAK_REALM>
+                                    <KEYCLOAK_CLIENTID>${keycloak.clientId}</KEYCLOAK_CLIENTID>
+                                    <KEYCLOAK_CLIENTSECRET>${keycloak.clientSecret}</KEYCLOAK_CLIENTSECRET>
+                                    <KEYCLOAK_PUBLICCLIENTID>entando-public</KEYCLOAK_PUBLICCLIENTID>
                                 </env>
                                 <dependsOn>
                                     <container>${entando.engine.depends.on}</container>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,11 @@
             <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.3.0.Final</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -14,7 +14,6 @@
             classpath*:spring/apsadmin/**/**.xml
             classpath*:spring/plugins/**/aps/**/**.xml
             classpath*:spring/plugins/**/apsadmin/**/**.xml
-            classpath:spring/web/servlet-context-keycloak.xml
         </param-value>
     </context-param>
     <context-param>
@@ -119,13 +118,13 @@
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-    
+
     <servlet>
         <servlet-name>springDispatcher</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
         <init-param>
             <param-name>contextConfigLocation</param-name>
-            <param-value>classpath:spring/web/servlet-context.xml</param-value>
+            <param-value>classpath:spring/web/servlet-context-keycloak.xml</param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
@@ -161,7 +160,7 @@
         <servlet-name>APIServlet</servlet-name>
         <url-pattern>/legacyapi/*</url-pattern>
     </servlet-mapping>
-    
+
     <session-config>
         <session-timeout>30</session-timeout>
     </session-config>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -14,6 +14,7 @@
             classpath*:spring/apsadmin/**/**.xml
             classpath*:spring/plugins/**/aps/**/**.xml
             classpath*:spring/plugins/**/apsadmin/**/**.xml
+            classpath:spring/web/servlet-context-keycloak.xml
         </param-value>
     </context-param>
     <context-param>
@@ -29,6 +30,10 @@
         <param-name>contextClass</param-name>
         <param-value>org.entando.entando.aps.system.XmlWebApplicationContext</param-value>
     </context-param>
+    <filter>
+        <filter-name>keycloakFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
     <filter>
         <filter-name>struts2</filter-name>
         <filter-class>com.agiletec.apsadmin.system.dispatcher.StrutsPrepareAndExecuteFilter</filter-class>
@@ -49,6 +54,12 @@
             <param-value>true</param-value>
         </init-param>
     </filter>
+    <filter-mapping>
+        <filter-name>keycloakFilter</filter-name>
+        <url-pattern>/do/login</url-pattern>
+        <url-pattern>/do/login.action</url-pattern>
+        <url-pattern>/do/logout.action</url-pattern>
+    </filter-mapping>
     <filter-mapping>
         <filter-name>struts2</filter-name>
         <url-pattern>/do/*</url-pattern>


### PR DESCRIPTION
This PR adds the keycloak plugin to the projects, define some sensible default values for keycloak env variables and creates a profile to enable keycloak during docker build.
Also in order to make this work, the web.xml is also updated to include keycloak filter and keycloak-servlet-context configuration 