### PR TITLE
Temporarily add the old PAM plugin so the widgets are present so the …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,14 +227,21 @@
             <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
-
-
         <dependency>
             <groupId>org.entando.entando.bundles.app-view</groupId>
             <artifactId>entando-app-view-cms-default</artifactId>
             <version>${entando.version}</version>
             <type>war</type>
         </dependency>
+
+<!--Temporarily add the PAM plugin so the old widgets are present -->
+        <dependency>
+           <groupId>org.entando.entando.plugins</groupId>
+           <artifactId>entando-plugin-jpkiebpm</artifactId>
+           <version>${entando.version}</version>
+           <type>war</type>
+        </dependency>
+
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
We have instructions that we give to the Red Hat team that we need to continue to match the installed environment. As soon as we get the new PAM plugin to a baseline state we should remove this dependency. 

And then burn the legacy plugin in the hottest fire we can find. 