### PR TITLE
ENG-1338 Fixes in the token generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </repositories>
     <properties>
         <entando-admin-console.version>6.2.40</entando-admin-console.version>
-        <entando-engine.version>6.2.58</entando-engine.version>
+        <entando-engine.version>6.2.60</entando-engine.version>
         <entando-portal-ui.version>6.2.7</entando-portal-ui.version>
         <entando-plugin-jacms.version>6.2.41</entando-plugin-jacms.version>
         <entando-plugin-jpmail.version>6.2.8</entando-plugin-jpmail.version>


### PR DESCRIPTION
Fixes in the token generation for old java versions.
Minimal java version supported is now: 1.8.0_265.